### PR TITLE
add option for passing kwargs to the (sub-)loaders

### DIFF
--- a/pybamm/experiments/experimentaldata.py
+++ b/pybamm/experiments/experimentaldata.py
@@ -17,6 +17,9 @@ class ExperimentalData(UserDict):
         Location of data container
     format: string
         currently "csv"
+    loader_kwargs: dict
+        keyword arguments passed to the loader
+
     Notes: example usage, how the data should look.
     """
 
@@ -25,7 +28,7 @@ class ExperimentalData(UserDict):
     cycle_index_column = "Cycle"
     step_index_column = "Step"
 
-    def __init__(self, filename, format="csv"):
+    def __init__(self, filename, format="csv", loader_kwargs=None):
         if format.lower() not in self.allowed:
             raise ValueError(
                 f"format '{format}' not allowed, only"
@@ -34,7 +37,8 @@ class ExperimentalData(UserDict):
 
         if not pathlib.Path(filename).is_file():
             raise ValueError(f"'{filename}' not found")
-
+        
+        self.loader_kwargs = loader_kwargs or {}
         self.format = format.lower()
         self.filename = filename
         self._data = None
@@ -51,7 +55,7 @@ class ExperimentalData(UserDict):
         self._validate()
 
     def _load_csv(self):
-        self._data = pd.read_csv(self.filename)
+        self._data = pd.read_csv(self.filename, **self.loader_kwargs)
 
     def _validate(self):
         cols = self._data.columns


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all`
- [ ] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
